### PR TITLE
fix: avoid scrolling to top when category filter changes

### DIFF
--- a/app/ClientPage.tsx
+++ b/app/ClientPage.tsx
@@ -4,7 +4,6 @@ import Fuse from 'fuse.js';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useMemo, useState } from 'react';
-import CheckIcon from '../components/Icons/CheckIcon';
 import InvestorTable from '../components/InvestorTable';
 import SearchBar from '../components/SearchBar';
 import Stats from '../components/Stats';
@@ -61,6 +60,7 @@ export default function Dashboard({ data }: any) {
         <span className="isolate mt-5 inline-flex rounded-md shadow-sm w-fit">
           {checkSizes.map((checkSize) => (
             <Link
+              scroll={false}
               href={checkSize.id !== '7' ? `/?category=${checkSize.id}` : '/'}
               key={checkSize.id}
               className={classNames(


### PR DESCRIPTION
On small screens (not only but it's more evident there), when we change the category filter, the page scrolls to the top which impacts the UX (for example, when we are on mobile). 

This is a PR to fix this by setting the `scroll` property to `false` in the `Link` component used for navigation (category filter changes).